### PR TITLE
Further Native fixes for runtime errors like  "Cannot construct instance of"

### DIFF
--- a/deployment/src/main/java/io/quarkus/amazon/lambda/alexa/deployment/AlexaProcessor.java
+++ b/deployment/src/main/java/io/quarkus/amazon/lambda/alexa/deployment/AlexaProcessor.java
@@ -71,6 +71,12 @@ public class AlexaProcessor {
                 .produce(new ReflectiveClassBuildItem(true, true, com.amazonaws.partitions.model.Region.class.getName()));
         reflectiveClasses
                 .produce(new ReflectiveClassBuildItem(true, true, com.amazonaws.partitions.model.Service.class.getName()));
+        reflectiveClasses
+                .produce(new ReflectiveClassBuildItem(true, true,
+                        com.amazonaws.services.dynamodbv2.model.ResourceInUseException.class.getName()));
+        reflectiveClasses
+                .produce(new ReflectiveClassBuildItem(true, true,
+                        com.fasterxml.jackson.databind.exc.InvalidDefinitionException.class.getName()));
     }
 
     @BuildStep


### PR DESCRIPTION
Fixes for issues of "Cannot construct instance of " during runtime like:

`2022-09-16 22:07:50,291 INFO  [com.ama.htt.JsonErrorResponseHandler] (Lambda Thread (NORMAL)) Unable to unmarshall exception content: com.fasterxml.jackson.databind.exc.InvalidDefinitionException: Cannot construct instance of `com.amazonaws.services.dynamodbv2.model.ResourceInUseException` (no Creators, like default constructor, exist): Throwable needs a default constructor, a single-String-arg constructor; or explicit @JsonCreator`


- https://github.com/quarkiverse/quarkus-amazon-alexa/pull/54
- https://github.com/quarkiverse/quarkus-amazon-alexa/issues/53